### PR TITLE
Fix PyGObject build

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,68 +1,87 @@
 #!/bin/bash
-cd `dirname $0`
+set -e
+cd "$(dirname "$0")"
 
+# Function to compare version numbers
 version_compare() {
-  if [[ $1 == $2 ]]
-  then
+  if [[ $1 == $2 ]]; then
       return 0
   fi
   local IFS=.
   local i ver1=($1) ver2=($2)
-  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
-  do
+  for (( i=${#ver1[@]}; i<${#ver2[@]}; i++ )); do
       ver1[i]=0
   done
-  for ((i=0; i<${#ver1[@]}; i++))
-  do
-      if [[ -z ${ver2[i]} ]]
-      then
+  for (( i=0; i<${#ver1[@]}; i++ )); do
+      if [[ -z ${ver2[i]} ]]; then
           ver2[i]=0
       fi
-      if ((10#${ver1[i]} > 10#${ver2[i]}))
-      then
+      if ((10#${ver1[i]} > 10#${ver2[i]})); then
           return 1
       fi
-      if ((10#${ver1[i]} < 10#${ver2[i]}))
-      then
+      if ((10#${ver1[i]} < 10#${ver2[i]})); then
           return 2
       fi
   done
   return 0
 }
 
-if [ -f .installed ]
-  then
+# If already installed, just activate the virtual environment.
+if [ -f .installed ]; then
     source viam-env/bin/activate
-  else
-    apt-get install python3-pip -y
+else
+    # Update and install required apt packages
+    apt-get update
+    apt-get install -y \
+      python3-pip \
+      python3.10-venv \
+      python3.10-dev \
+      build-essential \
+      libffi-dev \
+      libdbus-glib-1-dev \
+      libgirepository1.0-dev \
+      libcairo2-dev \
+      libxt-dev \
+      sqlite3 \
+      meson \
+      ninja-build \
+      cmake
+
+    # Create symlink so that pkg-config finds "girepository-2.0.pc"
+    if [ ! -f /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc ]; then
+        ln -s /usr/lib/aarch64-linux-gnu/pkgconfig/gobject-introspection-1.0.pc \
+              /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc
+    fi
+
+    # Export environment variables to help pkg-config and PyGObject find the necessary files.
+    export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+    export GI_TYPELIB_PATH=/usr/lib/aarch64-linux-gnu/girepository-1.0:$GI_TYPELIB_PATH
+
     # Get pip version
     pip_version=$(python3 -m pip --version | awk '{print $2}')
-
     echo "Detected pip version: $pip_version"
-
-    # Base command
     base_command="python3 -m pip install --user virtualenv"
-
-    # Check if pip version is 23.0 or higher
     if version_compare "$pip_version" "23.0"; then
         if [[ $? -eq 1 ]] || [[ $? -eq 0 ]]; then
             base_command="$base_command --break-system-packages"
         fi
     fi
-
     $base_command
-    
-    apt install python3.10-venv -y
+
+    # Create and activate the virtual environment
     python3 -m venv viam-env
     source viam-env/bin/activate
-    apt install build-essential libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev libxt-dev libgirepository1.0-dev sqlite3 -y
-    pip3 install --upgrade -r requirements.txt
-    if [ $? -eq 0 ]
-      then
-        touch .installed
-    fi
+    pip3 install --upgrade pip
+
+    # Force reinstall PyGObject at a version compatible with your system (3.42.1)
+    pip3 install --prefer-binary --force-reinstall "PyGObject==3.42.1"
+
+    # Install the remaining Python dependencies
+    pip3 install --prefer-binary -r requirements.txt
+
+    # Mark installation as successful
+    touch .installed
 fi
 
-# Be sure to use `exec` so that termination signals reach the python process,
-# or handle forwarding termination signals manually
-exec python3 -m main $@
+# Execute the main module
+exec python3 -m main "$@"

--- a/run.sh
+++ b/run.sh
@@ -4,29 +4,34 @@ cd "$(dirname "$0")"
 
 # Function to compare version numbers
 version_compare() {
-  if [[ $1 == $2 ]]; then
+  if [[ $1 == $2 ]] 
+  then
       return 0
   fi
   local IFS=.
   local i ver1=($1) ver2=($2)
-  for (( i=${#ver1[@]}; i<${#ver2[@]}; i++ )); do
+  for (( i=${#ver1[@]}; i<${#ver2[@]}; i++ )) 
+  do
       ver1[i]=0
   done
-  for (( i=0; i<${#ver1[@]}; i++ )); do
-      if [[ -z ${ver2[i]} ]]; then
+  for (( i=0; i<${#ver1[@]}; i++ ))
+  do
+      if [[ -z ${ver2[i]} ]] 
+      then
           ver2[i]=0
       fi
-      if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      if ((10#${ver1[i]} > 10#${ver2[i]})) 
+      then
           return 1
       fi
-      if ((10#${ver1[i]} < 10#${ver2[i]})); then
+      if ((10#${ver1[i]} < 10#${ver2[i]})) 
+      then
           return 2
       fi
   done
   return 0
 }
 
-# If already installed, just activate the virtual environment.
 if [ -f .installed ]; then
     source viam-env/bin/activate
 else
@@ -53,7 +58,7 @@ else
               /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc
     fi
 
-    # Export environment variables to help pkg-config and PyGObject find the necessary files.
+    # Export environment variables to help pkg-config and PyGObject find the necessary files
     export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
     export GI_TYPELIB_PATH=/usr/lib/aarch64-linux-gnu/girepository-1.0:$GI_TYPELIB_PATH
 
@@ -61,11 +66,14 @@ else
     pip_version=$(python3 -m pip --version | awk '{print $2}')
     echo "Detected pip version: $pip_version"
     base_command="python3 -m pip install --user virtualenv"
-    if version_compare "$pip_version" "23.0"; then
-        if [[ $? -eq 1 ]] || [[ $? -eq 0 ]]; then
+    if version_compare "$pip_version" "23.0" 
+    then
+        if [[ $? -eq 1 ]] || [[ $? -eq 0 ]]
+        then
             base_command="$base_command --break-system-packages"
         fi
     fi
+
     $base_command
 
     # Create and activate the virtual environment
@@ -73,7 +81,7 @@ else
     source viam-env/bin/activate
     pip3 install --upgrade pip
 
-    # Force reinstall PyGObject at a version compatible with your system (3.42.1)
+    # Force reinstall PyGObject at a version compatible with system
     pip3 install --prefer-binary --force-reinstall "PyGObject==3.42.1"
 
     # Install the remaining Python dependencies

--- a/run.sh
+++ b/run.sh
@@ -4,27 +4,27 @@ cd "$(dirname "$0")"
 
 # Function to compare version numbers
 version_compare() {
-  if [[ $1 == $2 ]] 
+  if [[ $1 == $2 ]]
   then
       return 0
   fi
   local IFS=.
   local i ver1=($1) ver2=($2)
-  for (( i=${#ver1[@]}; i<${#ver2[@]}; i++ )) 
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)) 
   do
       ver1[i]=0
   done
-  for (( i=0; i<${#ver1[@]}; i++ ))
+  for ((i=0; i<${#ver1[@]}; i++))
   do
-      if [[ -z ${ver2[i]} ]] 
+      if [[ -z ${ver2[i]} ]]
       then
           ver2[i]=0
       fi
-      if ((10#${ver1[i]} > 10#${ver2[i]})) 
+      if ((10#${ver1[i]} > 10#${ver2[i]}))
       then
           return 1
       fi
-      if ((10#${ver1[i]} < 10#${ver2[i]})) 
+      if ((10#${ver1[i]} < 10#${ver2[i]}))
       then
           return 2
       fi
@@ -32,7 +32,8 @@ version_compare() {
   return 0
 }
 
-if [ -f .installed ]; then
+if [ -f .installed ];
+then
     source viam-env/bin/activate
 else
     # Update and install required apt packages
@@ -53,7 +54,8 @@ else
       cmake
 
     # Create symlink so that pkg-config finds "girepository-2.0.pc"
-    if [ ! -f /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc ]; then
+    if [ ! -f /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc ]
+    then
         ln -s /usr/lib/aarch64-linux-gnu/pkgconfig/gobject-introspection-1.0.pc \
               /usr/lib/aarch64-linux-gnu/pkgconfig/girepository-2.0.pc
     fi
@@ -66,6 +68,7 @@ else
     pip_version=$(python3 -m pip --version | awk '{print $2}')
     echo "Detected pip version: $pip_version"
     base_command="python3 -m pip install --user virtualenv"
+    # Check if pip version is 23.0 or higher
     if version_compare "$pip_version" "23.0" 
     then
         if [[ $? -eq 1 ]] || [[ $? -eq 0 ]]

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ version_compare() {
   fi
   local IFS=.
   local i ver1=($1) ver2=($2)
-  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)) 
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
   do
       ver1[i]=0
   done
@@ -32,7 +32,7 @@ version_compare() {
   return 0
 }
 
-if [ -f .installed ];
+if [ -f .installed ]
 then
     source viam-env/bin/activate
 else


### PR DESCRIPTION
This PR updates the `run.sh` script to address issues encountered when installing the `bluetooth-presence` module on AArch64 devices (e.g., Ubuntu 22.04 on NVIDIA Jetson).

The `bluetooth-presence` module was failing to install because PyGObject's build process could not locate the required `girepository-2.0` dependency. By installing the additional packages, creating the necessary symlink, exporting the proper environment variables, and using a compatible version of PyGObject, this PR resolves those build issues and allows the module to install reliably.

