### PR TITLE
Pin PyGObject version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 viam-sdk~=0.41.1
 dbus-python~=1.2.16
-PyGObject
+PyGObject==3.42.1
 pycairo


### PR DESCRIPTION
This PR fixes installation issues with the `viam-bluetooth-presence` module on systems with girepository 1.72.0 (e.g., Ubuntu 22.04). Previously, the module would attempt to install the latest PyGObject, which requires girepository ≥ 2.80.0, causing build failures. When newer Ubuntu versions with girepository ≥ 2.80.0 become common in our deployment targets, we can remove or update this constraint.
