### PR TITLE
Add onboard Bluetooth GPIO initialization

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -64,7 +64,7 @@ def enable_onboard_bluetooth():
         )
         
         if "UP RUNNING" in check_bluetooth.stdout:
-            LOGGER.info("Bluetooth is already up and running, skipping GPIO activation now")
+            LOGGER.info("Bluetooth is already up and running, skipping GPIO activation")
             return True
 
         # Check if the gpiofind command is available and can find GPIO pin PA.04 on the board

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -151,19 +151,10 @@ class bluetooth(Sensor, Reconfigurable):
     # Constructor
     @classmethod
     def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:
-        LOGGER.info("Creating new bluetooth sensor instance...")
-        try:
-            LOGGER.info("Restarting bluetooth without a2dp...")
-            restart_bluetooth_without_a2dp()
-            LOGGER.info("Bluetooth restart complete, creating class instance...")
-            my_class = cls(config.name)
-            LOGGER.info("Class instance created, reconfiguring...")
-            my_class.reconfigure(config, dependencies)
-            LOGGER.info("Reconfiguration complete")
-            return my_class
-        except Exception as e:
-            LOGGER.error(f"Error in bluetooth.new(): {e}", exc_info=True)
-            raise
+        restart_bluetooth_without_a2dp()
+        my_class = cls(config.name)
+        my_class.reconfigure(config, dependencies)
+        return my_class
 
     # Validates JSON Configuration
     @classmethod

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -84,8 +84,13 @@ def enable_onboard_bluetooth():
             LOGGER.info("Successfully enabled onboard Bluetooth via GPIO PA.04")
             return True
         else:
-            LOGGER.warning(f"Failed to enable onboard Bluetooth: {result.stderr}")
-            return False
+            # If "busy" error, then consider it success since pin is already set
+            if "busy" in result.stderr.lower():
+                LOGGER.info("GPIO pin PA.04 is already active, continuing with initialization")
+                return True
+            else:
+                LOGGER.warning(f"Failed to enable onboard Bluetooth: {result.stderr}")
+                return False
             
     except (subprocess.SubprocessError, OSError) as e:
         LOGGER.warning(f"Error attempting to enable onboard Bluetooth: {str(e)}")

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -109,7 +109,6 @@ def enable_onboard_bluetooth():
 try:
     LOGGER.info("Attempting to enable onboard Bluetooth...")
     enable_onboard_bluetooth()
-    LOGGER.info("Onboard Bluetooth initialization completed")
 except Exception as e:
     LOGGER.error(f"Error during onboard Bluetooth initialization: {e}")
 

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -63,9 +63,17 @@ def restart_bluetooth_without_a2dp():
     # Enabling onboard Bluetooth
     try:
         # Find the GPIO pin name and set it
-        gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
+        # gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
         # Start the GPIO setting in the background to keep it active
-        subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
+        # subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
+        
+        command = "sudo gpioset --mode=signal $(gpiofind PA.04)=1"
+        LOGGER.info(f"Executing GPIO command: {command}")
+        
+        # Run the exact command that works in the shell
+        subprocess.run(command, shell=True, check=True)
+        LOGGER.info("Successfully enabled onboard Bluetooth via GPIO")
+
         LOGGER.info("Enabled onboard Bluetooth via GPIO")
         # Give hardware a moment to initialize
         time.sleep(3)
@@ -280,11 +288,17 @@ class BluetoothManager:
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.bus = dbus.SystemBus()
         
-        # Explicitly enable the Bluetooth hardware first
         try:
             # Activate GPIO before even attempting to find adapter
-            gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
-            subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
+            # gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
+            # subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
+            
+            command = "sudo gpioset --mode=signal $(gpiofind PA.04)=1"
+            LOGGER.info(f"Executing GPIO command: {command}")
+
+            # Run the exact command that works in the shell
+            subprocess.run(command, shell=True, check=True)
+            LOGGER.info("Successfully enabled onboard Bluetooth via GPIO")
             LOGGER.info(f"Enabled onboard Bluetooth via GPIO {gpio_pin}")
             
             # Give the system time to initialize hardware

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -319,7 +319,7 @@ class BluetoothManager:
                 time.sleep(1)
         
         if not self.adapter_path:
-            LOGGER.error("No Bluetooth adapter found after retries")
+            LOGGER.error("No Bluetooth adapter found")
             raise RuntimeError("No Bluetooth adapter found")
 
         self.paired_devices = {}

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -53,7 +53,7 @@ LOGGER = getLogger(__name__)
 PID_FILE = "/tmp/bluetoothd_program.pid"
 
 def enable_onboard_bluetooth():
-     # Check if the gpiofind command is available and can find PA.04
+     # Check if the gpiofind command is available and can find GPIO pin PA.04 on the board
     try:
         find_result = subprocess.run(
             ["gpiofind", "PA.04"], 
@@ -69,9 +69,12 @@ def enable_onboard_bluetooth():
         # If PA.04 exists, then activate it
         LOGGER.info("GPIO pin PA.04 detected (activating), enabling onboard Bluetooth...")
         
+        # Formatting the GPIO line and value
+        gpio_pin = find_result.stdout.strip()
+        
         # Using mode=signal to ensure GPIO state persists
         result = subprocess.run(
-            ["sudo", "gpioset", "--mode=signal", find_result.stdout.strip() + "=1"], 
+            ["sudo", "gpioset", "--mode=signal", gpio_pin.split()[0], f"{gpio_pin.split()[1]}=1"], 
             capture_output=True, 
             text=True,
             check=False
@@ -87,6 +90,9 @@ def enable_onboard_bluetooth():
     except (subprocess.SubprocessError, OSError) as e:
         LOGGER.warning(f"Error attempting to enable onboard Bluetooth: {str(e)}")
         return False
+
+# Activate GPIO for onboard Bluetooth at module load time (before adapter detection)
+enable_onboard_bluetooth()
 
 # the plugin a2dp seems to "take over" device audio, so we take over the bluetoothd
 # to disable plugin, preventing this from happening.  

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -65,7 +65,7 @@ def restart_bluetooth_without_a2dp():
         # Find the GPIO pin name and set it
         gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
         # Start the GPIO setting in the background to keep it active
-        subprocess.Popen(["gpioset", "--mode=signal", f"{gpio_pin}=1"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
         LOGGER.info("Enabled onboard Bluetooth via GPIO")
         # Give hardware a moment to initialize
         time.sleep(3)
@@ -284,7 +284,7 @@ class BluetoothManager:
         try:
             # Activate GPIO before even attempting to find adapter
             gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
-            subprocess.run(["gpioset", "--mode=signal", f"{gpio_pin}=1"], check=True)
+            subprocess.run(["gpioset", "--mode=signal", gpio_value.split()[0], f"{gpio_value.split()[1]}=1"], check=True)
             LOGGER.info(f"Enabled onboard Bluetooth via GPIO {gpio_pin}")
             
             # Give the system time to initialize hardware

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -67,10 +67,11 @@ def restart_bluetooth_without_a2dp():
         # Start the GPIO setting in the background to keep it active
         subprocess.Popen(["gpioset", "--mode=signal", gpio_pin + "=1"], 
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        LOGGER.info("Enabled onboard Bluetooth via GPIO")
         # Give hardware a moment to initialize
         time.sleep(2)
     except Exception as e:
-        LOGGER.debug(f"Could not enable onboard Bluetooth: {e}")
+        LOGGER.debug(f"Could not enable onboard Bluetooth. USB adapter may be required: {e}")
     
     bluetoothd_process = subprocess.Popen(["bluetoothd", "-P", "a2dp"])
     with open(PID_FILE, "w") as f:

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -65,8 +65,7 @@ def restart_bluetooth_without_a2dp():
         # Find the GPIO pin name and set it
         gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
         # Start the GPIO setting in the background to keep it active
-        subprocess.Popen(["gpioset", "--mode=signal", f"{gpio_pin}=1"], 
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.Popen(["gpioset", "--mode=signal", f"{gpio_pin}=1"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         LOGGER.info("Enabled onboard Bluetooth via GPIO")
         # Give hardware a moment to initialize
         time.sleep(3)
@@ -296,8 +295,7 @@ class BluetoothManager:
                         # Find the GPIO pin name and set it
                         gpio_pin = subprocess.check_output(["gpiofind", "PA.04"]).decode().strip()
                         # Start the GPIO setting in the background
-                        subprocess.Popen(["gpioset", "--mode=signal", f"{gpio_pin}=1"], 
-                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                        subprocess.Popen(["gpioset", "--mode=signal", f"{gpio_pin}=1"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         LOGGER.info(f"Enabled onboard Bluetooth via GPIO {gpio_pin} (retry {retry_count+1})")
                         # Give hardware time to initialize
                         time.sleep(3)


### PR DESCRIPTION
This PR enables the built-in Bluetooth capability on ForeCR Nvidia Jetson Orin NX boards with RTL8822CE wireless cards. The Bluetooth chip requires GPIO pin PA.04 to be activated before it becomes available to the system. This implementation is hardware-specific to the ForeCR Nvidia Jetson Orin NX configuration, but falls back to USB adapters when the onboard Bluetooth can't be activated.